### PR TITLE
Update app/views/mylyn_connector/information/version.xml.builder

### DIFF
--- a/app/views/mylyn_connector/information/version.xml.builder
+++ b/app/views/mylyn_connector/information/version.xml.builder
@@ -5,6 +5,7 @@ xml.version root_attribs do
     :minor => @data[1],
     :tiny => @data[2])
   xml.redmine Redmine::VERSION
-  xml.rails	Gem.loaded_specs["rails"].version
+  #xml.rails	Gem.loaded_specs["rails"].version
  #xml.rails RAILS_GEM_VERSION
+ xml.rails Rails::VERSION::STRING
 end


### PR DESCRIPTION
Updated the xml.rails var to Rails::VERSION::STRING, which is agnostic of whether rails is running via a Gem. Gentoo doesn't use gems when installed via its package manager (portage).
