### PR TITLE
Fix visibility in query

### DIFF
--- a/app/controllers/mylyn_connector/queries_controller.rb
+++ b/app/controllers/mylyn_connector/queries_controller.rb
@@ -12,7 +12,7 @@ class MylynConnector::QueriesController < MylynConnector::ApplicationController
     @queries = Query.find(
       :all,
       :joins => ["left join #{Project.table_name} on project_id=#{Project.table_name}.id"],
-      :conditions => ["(#{Query.table_name}.is_public = ? OR #{Query.table_name}.user_id = ?) AND (project_id IS NULL OR "  << Project.visible_condition(User.current) << ")", true, User.current.id],
+      :conditions => ["(#{Query.table_name}.visibility = ? OR #{Query.table_name}.user_id = ?) AND (project_id IS NULL OR "  << Project.visible_condition(User.current) << ")", Query::VISIBILITY_PUBLIC, User.current.id],
       :order => "#{Query.table_name}.name ASC"
     )
 


### PR DESCRIPTION
Query.is_public was replaced by Query.visibility
in recent versions (see #1019).

Update plugin queries.

Signed-off-by: Martin Abente Lahaye martin.abente.lahaye@gmail.com
