### PR TITLE
Fixed badly created issues queries resulting in returning all issues

### DIFF
--- a/app/controllers/mylyn_connector/issues_controller.rb
+++ b/app/controllers/mylyn_connector/issues_controller.rb
@@ -59,7 +59,7 @@ class MylynConnector::IssuesController < MylynConnector::ApplicationController
     @issues = Issue.find(
       :all,
       :joins => ["join #{Project.table_name} on project_id=#{Project.table_name}.id"],
-      :conditions => ["#{Issue.table_name}.id in (?) and #{Issue.table_name}.updated_on >= ? and " << Project.visible_condition(User.current), issues, cond]
+      :conditions => ["#{Issue.table_name}.id in (?) and #{Issue.table_name}.updated_on >= ? and (" << Project.visible_condition(User.current) << ")", issues, cond]
     )
     respond_to do |format|
       format.xml {render :layout => nil}
@@ -75,7 +75,7 @@ class MylynConnector::IssuesController < MylynConnector::ApplicationController
     @issues = Issue.find(
       :all,
       :joins => ["join #{Project.table_name} on project_id=#{Project.table_name}.id"],
-      :conditions => ["#{Issue.table_name}.id in (?) and " << Project.visible_condition(User.current), issues]
+      :conditions => ["#{Issue.table_name}.id in (?) and (" << Project.visible_condition(User.current) << ")", issues] 
     )
     respond_to do |format|
       format.xml {render :layout => nil}

--- a/app/controllers/mylyn_connector/projects_controller.rb
+++ b/app/controllers/mylyn_connector/projects_controller.rb
@@ -10,7 +10,7 @@ class MylynConnector::ProjectsController < MylynConnector::ApplicationController
   def all
     @projects = Project.find(:all,
       :joins => :enabled_modules,
-      :conditions => [ "enabled_modules.name = 'issue_tracking' AND #{Project.visible_condition(User.current)}"])
+      :conditions => [ "enabled_modules.name = 'issue_tracking' AND (#{Project.visible_condition(User.current)})"])
 
     respond_to do |format|
       format.xml {render :layout => nil}

--- a/app/controllers/mylyn_connector/queries_controller.rb
+++ b/app/controllers/mylyn_connector/queries_controller.rb
@@ -12,7 +12,7 @@ class MylynConnector::QueriesController < MylynConnector::ApplicationController
     @queries = Query.find(
       :all,
       :joins => ["left join #{Project.table_name} on project_id=#{Project.table_name}.id"],
-      :conditions => ["(#{Query.table_name}.visibility = ? OR #{Query.table_name}.user_id = ?) AND (project_id IS NULL OR "  << Project.visible_condition(User.current) << ")", Query::VISIBILITY_PUBLIC, User.current.id],
+      :conditions => ["(#{Query.table_name}.visibility = ? OR #{Query.table_name}.user_id = ?) AND (project_id IS NULL OR ("  << Project.visible_condition(User.current) << "))", Query::VISIBILITY_PUBLIC, User.current.id],
       :order => "#{Query.table_name}.name ASC"
     )
 


### PR DESCRIPTION
This fixes situation, when some plugin makes part of query generated by `Project.visible_condition(User.current)` contain various combination of OR's, which results in returning all of issues in affected queries.
